### PR TITLE
Closes #76

### DIFF
--- a/PhotoPoints/Views/Plant Library/ItemDetailView.swift
+++ b/PhotoPoints/Views/Plant Library/ItemDetailView.swift
@@ -14,6 +14,7 @@ class ItemDetailView: UIViewController {
     // MARK: - Properties
     let repository = Repository.instance
     var thisItem: Item
+    var alertDelegate: AlertDelegate!
     
     lazy var imageView: UIImageView = {
         let imageView = UIImageView(image: repository.getImage(item: thisItem))
@@ -108,6 +109,15 @@ class ItemDetailView: UIViewController {
         view.backgroundColor = UIColor(named: "pp-background")
         title = repository.getDetailValue(item: thisItem, property: "common_name")
         setUpScrollView()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        // using alertDelegate for scanner preview of this view but not in the library
+        if let alertDelegate = alertDelegate {
+            alertDelegate.turnOffAlert()
+        }
     }
     
     func setUpScrollView() {

--- a/PhotoPoints/Views/Scanner/ScannerView.swift
+++ b/PhotoPoints/Views/Scanner/ScannerView.swift
@@ -16,6 +16,7 @@ class ScannerView: UIViewController {
     
     let repository = Repository.instance
     
+    // keeps track of whether or not an alert should be allowed to present when scanning
     var alertActive = false
     
     // video session: optional because we won't have it in our emulator
@@ -113,40 +114,10 @@ class ScannerView: UIViewController {
     
 }
 
-// MARK: - Image Picker
-
-extension ScannerView: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
-    
-    func openCamera() {
-        let imagePicker = UIImagePickerController()
-        imagePicker.delegate = self
-        imagePicker.sourceType = .camera
-        imagePicker.allowsEditing = false
-        imagePicker.showsCameraControls = true
-        self.present(imagePicker, animated: true, completion: nil)
-    }
-    
-    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-        if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
-            let hashString = String(image.hashValue)
-            ImageManager.storeImage(image: image, with: hashString)
-            self.dismiss(animated: true, completion: nil)
-        } else {
-            print("error")
-        }
-    }
-    
-}
-
 // MARK: - Meta Data Output
 
-extension ScannerView: AVCaptureMetadataOutputObjectsDelegate, AlertDelegate {
-    
-    func turnOffAlert() {
-        self.alertActive = false
-        print("alert inactive")
-    }
-    
+extension ScannerView: AVCaptureMetadataOutputObjectsDelegate {
+
     // called by system when we get metadataoutputs
     func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
         if  metadataObjects.count != 0 && !alertActive {
@@ -168,14 +139,15 @@ extension ScannerView: AVCaptureMetadataOutputObjectsDelegate, AlertDelegate {
     func setUpAlerts(for item: Item) {
         let commonName = repository.getDetailValue(item: item, property: "common_name")
         let botanicalName = repository.getDetailValue(item: item, property: "botanical_name")
+        let detailView = ItemDetailView(item: item)
+        detailView.alertDelegate = self
         
-        let scannedAlert = Alert(title: commonName, message: botanicalName, preferredStyle: .alert)
-        scannedAlert.delegate = self
+        let scannedAlert = UIAlertController(title: commonName, message: botanicalName, preferredStyle: .alert)
         scannedAlert.addAction(UIAlertAction(title: "Perform Survey", style: .default, handler: { (nil) in
             self.openCamera()
         }))
         scannedAlert.addAction(UIAlertAction(title: "Learn More", style: .default, handler: { (nil) in
-            self.present(ItemDetailView(item: item), animated: true, completion: nil)
+            self.present(detailView, animated: true, completion: nil)
         }))
         
         present(scannedAlert, animated: true, completion: nil)
@@ -183,16 +155,49 @@ extension ScannerView: AVCaptureMetadataOutputObjectsDelegate, AlertDelegate {
     
 }
 
+// MARK: - Image Picker
+
 protocol AlertDelegate {
     func turnOffAlert()
 }
 
-class Alert: UIAlertController {
+class ImagePickerWithAlertDelegate: UIImagePickerController {
     
-    var delegate: AlertDelegate! = nil
+    // initialized to nil so we don't have to write a custom init
+    var alertDelegate: AlertDelegate! = nil
     
     override func viewDidDisappear(_ animated: Bool) {
-        delegate.turnOffAlert()
+        super.viewDidDisappear(animated)
+        alertDelegate.turnOffAlert()
+    }
+    
+}
+
+extension ScannerView: UIImagePickerControllerDelegate, UINavigationControllerDelegate, AlertDelegate {
+    
+    func turnOffAlert() {
+        self.alertActive = false
+        print("alert inactive")
+    }
+    
+    func openCamera() {
+        let imagePicker = ImagePickerWithAlertDelegate()
+        imagePicker.delegate = self
+        imagePicker.alertDelegate = self
+        imagePicker.sourceType = .camera
+        imagePicker.allowsEditing = false
+        imagePicker.showsCameraControls = true
+        self.present(imagePicker, animated: true, completion: nil)
+    }
+    
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+            let hashString = String(image.hashValue)
+            ImageManager.storeImage(image: image, with: hashString)
+            self.dismiss(animated: true, completion: nil)
+        } else {
+            print("error")
+        }
     }
     
 }

--- a/PhotoPoints/Views/Scanner/ScannerView.swift
+++ b/PhotoPoints/Views/Scanner/ScannerView.swift
@@ -140,7 +140,13 @@ extension ScannerView: UIImagePickerControllerDelegate, UINavigationControllerDe
 
 // MARK: - Meta Data Output
 
-extension ScannerView: AVCaptureMetadataOutputObjectsDelegate {
+extension ScannerView: AVCaptureMetadataOutputObjectsDelegate, AlertDelegate {
+    
+    func turnOffAlert() {
+        self.alertActive = false
+        print("alert inactive")
+    }
+    
     // called by system when we get metadataoutputs
     func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
         if  metadataObjects.count != 0 && !alertActive {
@@ -150,6 +156,8 @@ extension ScannerView: AVCaptureMetadataOutputObjectsDelegate {
                 
                 if qrCodes.contains(objectString) {
                     if let thisItem = repository.getItemFromQrCode(qrCode: objectString) {
+                        alertActive = true
+                        print("alert active")
                         setUpAlerts(for: thisItem)
                     }
                 }
@@ -161,7 +169,8 @@ extension ScannerView: AVCaptureMetadataOutputObjectsDelegate {
         let commonName = repository.getDetailValue(item: item, property: "common_name")
         let botanicalName = repository.getDetailValue(item: item, property: "botanical_name")
         
-        let scannedAlert = UIAlertController(title: commonName, message: botanicalName, preferredStyle: .alert)
+        let scannedAlert = Alert(title: commonName, message: botanicalName, preferredStyle: .alert)
+        scannedAlert.delegate = self
         scannedAlert.addAction(UIAlertAction(title: "Perform Survey", style: .default, handler: { (nil) in
             self.openCamera()
         }))
@@ -174,3 +183,16 @@ extension ScannerView: AVCaptureMetadataOutputObjectsDelegate {
     
 }
 
+protocol AlertDelegate {
+    func turnOffAlert()
+}
+
+class Alert: UIAlertController {
+    
+    var delegate: AlertDelegate! = nil
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        delegate.turnOffAlert()
+    }
+    
+}

--- a/PhotoPoints/Views/Scanner/ScannerView.swift
+++ b/PhotoPoints/Views/Scanner/ScannerView.swift
@@ -16,6 +16,8 @@ class ScannerView: UIViewController {
     
     let repository = Repository.instance
     
+    var alertActive = false
+    
     // video session: optional because we won't have it in our emulator
     var session: AVCaptureSession! = nil
     
@@ -141,12 +143,9 @@ extension ScannerView: UIImagePickerControllerDelegate, UINavigationControllerDe
 extension ScannerView: AVCaptureMetadataOutputObjectsDelegate {
     // called by system when we get metadataoutputs
     func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
-        if  metadataObjects.count != 0 {
+        if  metadataObjects.count != 0 && !alertActive {
             if let object = metadataObjects[0] as? AVMetadataMachineReadableCodeObject {
-                
                 let qrCodes = repository.getQrCodes()
-                print(qrCodes)
-                
                 let objectString = object.stringValue ?? ""
                 
                 if qrCodes.contains(objectString) {
@@ -166,9 +165,10 @@ extension ScannerView: AVCaptureMetadataOutputObjectsDelegate {
         scannedAlert.addAction(UIAlertAction(title: "Perform Survey", style: .default, handler: { (nil) in
             self.openCamera()
         }))
-        scannedAlert.addAction(UIAlertAction(title: "Learn More", style: .default, handler:  { (nil) in
+        scannedAlert.addAction(UIAlertAction(title: "Learn More", style: .default, handler: { (nil) in
             self.present(ItemDetailView(item: item), animated: true, completion: nil)
         }))
+        
         present(scannedAlert, animated: true, completion: nil)
     }
     


### PR DESCRIPTION
Applies simple delegate pattern to notify the scanner view whenever either the imagepicker (camera) or modally presented detail view are closed, so scanning can resume.