### PR TITLE
Closes #125

### DIFF
--- a/PhotoPoints.xcodeproj/project.pbxproj
+++ b/PhotoPoints.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		F30CA2962460A3D800CEA2A6 /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30CA2652460A3D700CEA2A6 /* MapView.swift */; };
 		F30CA2982460A3D800CEA2A6 /* AnchorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30CA2682460A3D700CEA2A6 /* AnchorExtension.swift */; };
 		F347B06424E8D1A700E76E3B /* PhotoPoints.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = F347B06224E8D1A700E76E3B /* PhotoPoints.xcdatamodeld */; };
+		F3605557258AB8DF00817995 /* LoadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3605556258AB8DF00817995 /* LoadView.swift */; };
 		F38F504B24EC81B700016F8C /* Image+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38F503F24EC81B700016F8C /* Image+CoreDataClass.swift */; };
 		F38F504C24EC81B700016F8C /* Image+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38F504024EC81B700016F8C /* Image+CoreDataProperties.swift */; };
 		F38F504D24EC81B700016F8C /* Coordinate+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38F504124EC81B700016F8C /* Coordinate+CoreDataClass.swift */; };
@@ -88,6 +89,7 @@
 		F30CA2652460A3D700CEA2A6 /* MapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		F30CA2682460A3D700CEA2A6 /* AnchorExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnchorExtension.swift; sourceTree = "<group>"; };
 		F347B06324E8D1A700E76E3B /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
+		F3605556258AB8DF00817995 /* LoadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadView.swift; sourceTree = "<group>"; };
 		F38F503F24EC81B700016F8C /* Image+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+CoreDataClass.swift"; sourceTree = "<group>"; };
 		F38F504024EC81B700016F8C /* Image+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		F38F504124EC81B700016F8C /* Coordinate+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coordinate+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 			isa = PBXGroup;
 			children = (
 				F30CA2362460A3D700CEA2A6 /* ScannerView.swift */,
+				F3605556258AB8DF00817995 /* LoadView.swift */,
 			);
 			path = Scanner;
 			sourceTree = "<group>";
@@ -330,6 +333,7 @@
 			files = (
 				F30CA26C2460A3D800CEA2A6 /* ScannerView.swift in Sources */,
 				F3095931246BA1A40088FB19 /* ImageManager.swift in Sources */,
+				F3605557258AB8DF00817995 /* LoadView.swift in Sources */,
 				F30CA2802460A3D800CEA2A6 /* ItemCollectionView.swift in Sources */,
 				F30CA2032460A2F800CEA2A6 /* AppDelegate.swift in Sources */,
 				F38F504D24EC81B700016F8C /* Coordinate+CoreDataClass.swift in Sources */,

--- a/PhotoPoints/View/Scanner/LoadView.swift
+++ b/PhotoPoints/View/Scanner/LoadView.swift
@@ -12,23 +12,11 @@ class LoadView: UIView {
 
     let indicator = UIActivityIndicatorView(style: .large)
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        backgroundColor = UIColor(named: "pp-trans-gray")
-        setUpIndicator()
-    }
-    
     func setUpIndicator() {
         indicator.color = UIColor(named: "pp-text-color")
         addSubview(indicator)
-        indicator.translatesAutoresizingMaskIntoConstraints = false
-        indicator.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
-        indicator.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+        indicator.frame = frame
         indicator.startAnimating()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 
 }

--- a/PhotoPoints/View/Scanner/LoadView.swift
+++ b/PhotoPoints/View/Scanner/LoadView.swift
@@ -1,0 +1,34 @@
+//
+//  loadView.swift
+//  PhotoPoints
+//
+//  Created by Clay Suttner on 12/16/20.
+//  Copyright © 2020 Cascadia College. All rights reserved.
+//
+
+import UIKit
+
+class LoadView: UIView {
+
+    let indicator = UIActivityIndicatorView(style: .large)
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = UIColor(named: "pp-trans-gray")
+        setUpIndicator()
+    }
+    
+    func setUpIndicator() {
+        indicator.color = UIColor(named: "pp-text-color")
+        addSubview(indicator)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        indicator.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+        indicator.startAnimating()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}

--- a/PhotoPoints/View/Scanner/ScannerView.swift
+++ b/PhotoPoints/View/Scanner/ScannerView.swift
@@ -30,6 +30,18 @@ class ScannerView: UIViewController {
         return square
     }()
     
+    let loadingScreen: UIView = {
+        let screen = UIView()
+        screen.backgroundColor = UIColor(named: "pp-trans-gray")
+        
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.startAnimating()
+        screen.addSubview(indicator)
+        indicator.anchor(top: screen.topAnchor, left: screen.leftAnchor, bottom: screen.bottomAnchor, right: screen.rightAnchor)
+        
+        return screen
+    }()
+    
     // MARK: - Lifecycle
     
     override func viewDidLoad() {
@@ -46,7 +58,13 @@ class ScannerView: UIViewController {
     // bring the session up again if we switch back to this view
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        showLoadScreen()
         session?.startRunning()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        loadingScreen.removeFromSuperview()
     }
     
     // MARK: - Scanner
@@ -98,6 +116,11 @@ class ScannerView: UIViewController {
         scannerSquare.anchor(width: width, height: width)
         scannerSquare.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
         scannerSquare.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+    }
+    
+    func showLoadScreen() {
+        view.addSubview(loadingScreen)
+        loadingScreen.anchor(top: view.topAnchor, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor)
     }
     
     func addNoAVDLabel() {
@@ -178,6 +201,7 @@ extension ScannerView: UIImagePickerControllerDelegate, UINavigationControllerDe
     }
     
     func openCamera() {
+        showLoadScreen()
         let imagePicker = ImagePickerWithAlertDelegate()
         imagePicker.delegate = self
         imagePicker.alertDelegate = self
@@ -185,7 +209,15 @@ extension ScannerView: UIImagePickerControllerDelegate, UINavigationControllerDe
         imagePicker.cameraDevice = .rear
         imagePicker.allowsEditing = false
         imagePicker.showsCameraControls = true
-        self.present(imagePicker, animated: true, completion: nil)
+        self.present(imagePicker, animated: true) { [weak self] in
+            if let loadingScreen = self?.loadingScreen {
+                
+                // check to make sure this is actually removing the load screen
+                loadingScreen.removeFromSuperview()
+                
+                print("completion called")
+            }
+        }
     }
     
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {

--- a/PhotoPoints/View/Scanner/ScannerView.swift
+++ b/PhotoPoints/View/Scanner/ScannerView.swift
@@ -30,13 +30,11 @@ class ScannerView: UIViewController {
         return square
     }()
     
-    let loadingScreen = LoadView(frame: UIScreen.main.bounds)
+    let loadingScreen = LoadView()
     
     // photo capture view
-    lazy var imagePicker: ImagePickerWithAlertDelegate = {
+    let imagePicker: ImagePickerWithAlertDelegate = {
         let ip = ImagePickerWithAlertDelegate()
-        ip.delegate = self
-        ip.alertDelegate = self
         ip.sourceType = .camera
         ip.cameraDevice = .rear
         ip.allowsEditing = false
@@ -49,6 +47,7 @@ class ScannerView: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupScanner()
+        addDelegates()
     }
     
     // terminate the session if we navigate off this view
@@ -119,6 +118,8 @@ class ScannerView: UIViewController {
     }
     
     func showLoadScreen() {
+        loadingScreen.frame = view.frame
+        loadingScreen.setUpIndicator()
         view.addSubview(loadingScreen)
     }
     
@@ -162,18 +163,16 @@ extension ScannerView: AVCaptureMetadataOutputObjectsDelegate {
         detailView.alertDelegate = self
         
         let scannedAlert = UIAlertController(title: commonName, message: botanicalName, preferredStyle: .alert)
-        scannedAlert.addAction(UIAlertAction(title: "Perform Survey", style: .default, handler: { _ in
+        scannedAlert.addAction(UIAlertAction(title: "Perform Survey", style: .default, handler: { (nil) in
             
             self.showLoadScreen()
             
             DispatchQueue.main.async {
-                
                 self.openCamera()
             }
             
-            
         }))
-        scannedAlert.addAction(UIAlertAction(title: "Learn More", style: .default, handler: { _ in
+        scannedAlert.addAction(UIAlertAction(title: "Learn More", style: .default, handler: { (nil) in
             
             self.showLoadScreen()
             
@@ -213,6 +212,11 @@ extension ScannerView: UIImagePickerControllerDelegate, UINavigationControllerDe
     func turnOffAlert() {
         self.alertActive = false
         print("alert inactive")
+    }
+    
+    func addDelegates() {
+        imagePicker.delegate = self
+        imagePicker.alertDelegate = self
     }
     
     func openCamera() {

--- a/PhotoPoints/View/Scanner/loadingView.swift
+++ b/PhotoPoints/View/Scanner/loadingView.swift
@@ -1,0 +1,9 @@
+//
+//  loadingView.swift
+//  PhotoPoints
+//
+//  Created by Clay Suttner on 12/16/20.
+//  Copyright © 2020 Cascadia College. All rights reserved.
+//
+
+import Foundation


### PR DESCRIPTION
Adds a loading screen that shows while the camera is being opened up, as I noticed this task was taking some time. There is also a loading screen that shows when the detail view is opened from the scanner (alert > learn more), but I may remove this.

The class LoadView can now be used for other long tasks, i.e. submitting a photo.