### PR TITLE
Closes #159

### DIFF
--- a/PhotoPoints/View/Capture/CaptureView.swift
+++ b/PhotoPoints/View/Capture/CaptureView.swift
@@ -241,6 +241,11 @@ extension CaptureView: UIImagePickerControllerDelegate, UINavigationControllerDe
         savePhoto(using: info)
     }
     
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        dismiss(animated: true) {}
+        enableScanning()
+    }
+    
     func savePhoto(using info: [UIImagePickerController.InfoKey : Any]) {
         // handle the user photo in the background (this really helps speed up the UI here!)
         DispatchQueue.global(qos: .userInitiated).async {


### PR DESCRIPTION
We had an issue with user testing that whenever the cancel action was chosen when taking a photo, scanning would stop working until app restart. This is because the delegate methods controlling whether the scanning should be enabled or disabled were only set up for the assumption that the user would always take a photo and never cancel (big oversight).

This change adds in a scan delegate method (`enableScanning()`)that is called when the imagePickerController (which handles the camera) is cancelled.