### PR TITLE
Closes #164

### DIFF
--- a/PhotoPoints/View/Capture/CaptureView.swift
+++ b/PhotoPoints/View/Capture/CaptureView.swift
@@ -131,8 +131,8 @@ class CaptureView: UIViewController {
         let detailView = PointsDetail(item: scannedItem)
         detailView.scanDelegate = self
         
-        let botanicalName = repository.getDetailValue(item: scannedItem, property: "botanical_name")
-        let scannedAlert = UIAlertController(title: scannedItem.label, message: botanicalName, preferredStyle: .alert)
+        let speciesName = repository.getDetailValue(item: scannedItem, property: "species_name")
+        let scannedAlert = UIAlertController(title: scannedItem.label, message: speciesName, preferredStyle: .alert)
         
         scannedAlert.addAction(UIAlertAction(title: "Learn More", style: .default, handler: { (nil) in
             self.present(detailView, animated: true) {}

--- a/PhotoPoints/View/Points/Detail/PointsDetail.swift
+++ b/PhotoPoints/View/Points/Detail/PointsDetail.swift
@@ -147,7 +147,7 @@ class PointsDetail: UIViewController {
             scanDelegate.enableScanning()
         }
 
-        dateViewDelegate.fadeInDate()
+        dateViewDelegate?.fadeInDate()
     }
     
     func addSubviews() {


### PR DESCRIPTION
A simple solution to this bug was to add optional chaining to the dateDelegate method call in the detail view's viewWillDissapear. Also changed the alert to reference "species_name" detail rather than erroneous "botanical_name" detail.

How could we make this reference to "botanical_name" generic? Is there another detail that would work for different types of points for this purpose?

Also, do we want to show the same detail view modally when scanning? This feels a little redundant to show the same screen in two different places, one embedded in a navigation controller and one presented modally. Idk.